### PR TITLE
Added merge strategy to build.sbt to prevent failure 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "nautilus-cloud"
 
-  version := "0.1"
+version := "0.1"
 
 scalaVersion := "2.12.8"
 


### PR DESCRIPTION
Some jars from io.netty are failing to merge during uber jar construction. This pr adds a merge strategy to handle them.

Additionally the output jar name is also set.